### PR TITLE
Optimised the way Library/Authentication.php gets the tables structur…

### DIFF
--- a/Classes/Library/Authentication.php
+++ b/Classes/Library/Authentication.php
@@ -546,7 +546,7 @@ class Authentication
         }
 
         $typo3Groups = array();
-
+        $defaultGroup = Typo3GroupRepository::create($table);
         foreach ($ldapGroups as $ldapGroup) {
             $groupName = null;
             if (isset($mapping['title']) &&  preg_match("`<([^$]*)>`", $mapping['title'])) {
@@ -558,7 +558,7 @@ class Authentication
             if (count($existingTypo3Groups) > 0) {
                 $typo3Group = $existingTypo3Groups[0];
             } else {
-                $typo3Group = Typo3GroupRepository::create($table);
+                $typo3Group = $defaultGroup;
                 $typo3Group['pid'] = (int)$pid;
                 $typo3Group['crdate'] = $GLOBALS['EXEC_TIME'];
                 $typo3Group['tstamp'] = $GLOBALS['EXEC_TIME'];
@@ -588,7 +588,7 @@ class Authentication
         }
 
         $typo3Users = array();
-
+        $defaultUser = Typo3UserRepository::create($table);
         foreach ($ldapUsers as $ldapUser) {
             $username = null;
             if (isset($mapping['username']) && preg_match("`<([^$]*)>`", $mapping['username'])) {
@@ -599,7 +599,7 @@ class Authentication
             if (count($existingTypo3Users) > 0) {
                 $typo3User = $existingTypo3Users[0];
             } else {
-                $typo3User = Typo3UserRepository::create($table);
+                $typo3User = $defaultUser;
                 $typo3User['pid'] = (int)$pid;
                 $typo3User['crdate'] = $GLOBALS['EXEC_TIME'];
                 $typo3User['tstamp'] = $GLOBALS['EXEC_TIME'];

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = array(
 In case of use in an intranet environment, this extension is a perfect match since it natively brings Single Sign-On (SSO) capability to TYPO3 without any complex configuration.',
     'category' => 'services',
     'shy' => 0,
-    'version' => '3.2.1',
+    'version' => '3.2.2',
     'dependencies' => '',
     'conflicts' => '',
     'priority' => '',


### PR DESCRIPTION
…e for users and groups

This is needed, since an installation with 500+ groups or users would require to get 500+ times
the structure of one or the other table, which is an unhandable drag on the database.
I've had an example of a client having 27k+ groups + 24k+ users which lead to 50k+
requests to MySQL telling it to return the structure of both of these tables which resulted
in a complete halt.