### PR TITLE
FIX: use correct group for recursive ldap groups refs #82503

### DIFF
--- a/Classes/Controller/ModuleController.php
+++ b/Classes/Controller/ModuleController.php
@@ -460,11 +460,11 @@ class ModuleController extends \TYPO3\CMS\Extbase\Mvc\Controller\ActionControlle
                 if (preg_match("`<([^$]*)>`", $fieldParent, $attribute)) {
                     $fieldParent = $attribute[1];
 
-                    if (is_array($group[$fieldParent])) {
-                        unset($group[$fieldParent]['count']);
+                    if (is_array($ldapGroup[$fieldParent])) {
+                        unset($ldapGroup[$fieldParent]['count']);
 
                         $this->setParentGroup(
-                            $group[$fieldParent],
+                            $ldapGroup[$fieldParent],
                             $fieldParent,
                             $group['uid'],
                             $pid,


### PR DESCRIPTION
Fixes the following issue.
https://forge.typo3.org/issues/82503